### PR TITLE
remove obsolete mut statement

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -156,7 +156,7 @@ impl Partition {
     }
 
     pub fn create_virtual_processor(
-        &mut self,
+        &self,
         index: UINT32,
     ) -> Result<VirtualProcessor, WHPError> {
         check_result(unsafe {


### PR DESCRIPTION
`create_virtual_processor` doesn't modify the struct => mutability isn't required 