### PR TITLE
Make WHV_UINT128 16 byte aligned

### DIFF
--- a/src/win_hv_platform_defs.rs
+++ b/src/win_hv_platform_defs.rs
@@ -879,6 +879,7 @@ pub struct WHV_RUN_VP_EXIT_CONTEXT {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 #[allow(non_snake_case)]
+#[repr(align(16))]
 #[repr(C)]
 pub struct WHV_UINT128 {
     pub Low64: UINT64,


### PR DESCRIPTION
This type needs to be aligned, otherwise it can lead to random exceptions.
