### PR TITLE
Re-enable register tests

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -643,7 +643,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_set_get_virtual_processor_registers() {
         let mut p: Partition = Partition::new().unwrap();
         setup_vcpu_test(&mut p);

--- a/src/win_hv_platform.rs
+++ b/src/win_hv_platform.rs
@@ -352,7 +352,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_set_get_vcpu_registers() {
         with_partition(|part| {
             with_vcpu(part, |vp_index| {


### PR DESCRIPTION
Those tests were previously crashing. This no longer happens after
fixing the WHV_UINT128 alignment so it should be safe to enable
them back.

Co-authored-by: Jenny Mankin <jenny.mankin@crowdstrike.com>