### PR TITLE
Add 'request_interrupt' method to Partition struct

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -190,6 +190,17 @@ impl Partition {
             flags: flags,
         })
     }
+
+    pub fn request_interrupt(&self, interrupt: &WHV_INTERRUPT_CONTROL) -> Result<(), WHPError> {
+        check_result(unsafe {
+            WHvRequestInterrupt(
+                *self.partition.borrow().handle(),
+                interrupt,
+                std::mem::size_of::<WHV_INTERRUPT_CONTROL>() as UINT32,
+            )
+        })?;
+        Ok(())
+    }
 }
 
 pub struct GPARangeMapping {


### PR DESCRIPTION
We're defining this method for vcpu structures, we should do the same
for partitions.

Note that the interrupt destination is actually part of the
interrupt structure, which is populated by the caller.