### PR TITLE
macro bitfield128 creates an overflow error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![warn(const_err)]
+
 extern crate libc;
 
 #[macro_use]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -156,7 +156,7 @@ impl Partition {
     }
 
     pub fn create_virtual_processor(
-        &mut self,
+        &self,
         index: UINT32,
     ) -> Result<VirtualProcessor, WHPError> {
         check_result(unsafe {


### PR DESCRIPTION
add "#![warn(const_err)]" as workaround (see https://github.com/rust-lang/rust/pull/50653)

Maybe you should revise your macro.