### PR TITLE
Fix 'attempt to shift left with overflow' in bitfield128 macro

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -239,10 +239,8 @@ fn send_ipi(vp: &mut VirtualProcessor, vector: u32) {
     //   contain the APIC ID of the target processor (APIC ID = 0)
     // Level = 1 and Destination Shorthand = 1, but the underlying API will
     // actually ignore this.
-    unsafe {
-        message.anon_struct.Data = (0x00044000 | vector) as UINT32;
-        message.anon_struct.Address = 0;
-    }
+    message.anon_struct.Data = (0x00044000 | vector) as UINT32;
+    message.anon_struct.Address = 0;
 
     send_msi(vp, &message);
 }

--- a/examples/payload/payload.c
+++ b/examples/payload/payload.c
@@ -141,9 +141,10 @@ static void gdt_set_descriptor(PGDT_ENTRY64 gdt, uint32_t index, uint32_t base,
 void
 initialize_gdt(PGDT_ENTRY64 gdt)
 {
-    DT_PTR64 gdt_ptr = { 0 };
+    DT_PTR64 gdt_ptr;
     uint32_t gdt_size = sizeof(GDT_ENTRY64) * NUM_GDT_ENTRIES;
 
+    memset(&gdt_ptr, 0, sizeof(gdt_ptr));
     memset(gdt, 0, gdt_size);
 
     // Fill in the special GDT pointer to be loaded into the GDT Register
@@ -161,7 +162,9 @@ initialize_gdt(PGDT_ENTRY64 gdt)
 
 void initialize_idt(PIDT_ENTRY64 idt)
 {
-    DT_PTR64 idt_ptr = { 0 };
+    DT_PTR64 idt_ptr;
+
+    memset(&idt_ptr, 0, sizeof(idt_ptr));
     
     uint32_t idt_size = sizeof(IDT_ENTRY64) * NUM_IDT_ENTRIES;
 

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -16,7 +16,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::error::{self, Error as InterruptsError};
 use std::fmt::{self, Display};
 use std::io::Cursor;
 use std::mem;
@@ -35,18 +34,13 @@ pub enum Error {
 }
 pub type Result<T> = result::Result<T, Error>;
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
-            &Error::GetLapic(_) => "GetLapic ioctl failed",
-            &Error::SetLapic(_) => "SetLapic ioctl failed",
-        }
-    }
-}
-
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Interrupt Error: {}", Error::description(self))
+        write!(f, "Interrupt Error: {}", 
+            match self {
+                &Error::GetLapic(_) => "GetLapic ioctl failed",
+                &Error::SetLapic(_) => "SetLapic ioctl failed",
+            })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![warn(const_err)]
+
 extern crate libc;
 
 #[macro_use]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -352,7 +352,7 @@ impl VirtualProcessor {
         gva: WHV_GUEST_PHYSICAL_ADDRESS,
         range_size_in_bytes: UINT64,
         bitmap_size_in_bytes: UINT32,
-    ) -> Result<(Box<[UINT64]>), WHPError> {
+    ) -> Result<Box<[UINT64]>, WHPError> {
         let num_elem = bitmap_size_in_bytes / std::mem::size_of::<UINT64>() as UINT32;
         let mut bitmap: Box<[UINT64]> = vec![0; num_elem as usize].into_boxed_slice();
 
@@ -411,7 +411,7 @@ impl VirtualProcessor {
     pub fn get_partition_counters(
         &self,
         partition_counter_set: WHV_PARTITION_COUNTER_SET,
-    ) -> Result<(WHV_PARTITION_COUNTERS), WHPError> {
+    ) -> Result<WHV_PARTITION_COUNTERS, WHPError> {
         let mut partition_counters: WHV_PARTITION_COUNTERS = Default::default();
         let mut bytes_written: UINT32 = 0;
 
@@ -471,7 +471,7 @@ impl VirtualProcessor {
         Ok(processor_counters)
     }
 
-    pub fn get_xsave_state(&self) -> Result<(XsaveArea), WHPError> {
+    pub fn get_xsave_state(&self) -> Result<XsaveArea, WHPError> {
         let mut xsave_area: XsaveArea = Default::default();
         let mut bytes_written: UINT32 = 0;
 


### PR DESCRIPTION
This change addresses the arithmetic overflow build error in the bitfield128 macro with the latest Rust toolchain without relying on #[allow(const_err)].

Verified that tests pass and the demo example works as expected.

The error this resolves is below:

error: this arithmetic operation will overflow
   --> src\macros.rs:65:21
    |
65  | /                     self.$field.High64 <<
66  | |                         (128 - $r.end) >> (64 - $r.end + $r.start)
    | |______________________________________^ attempt to shift left with overflow